### PR TITLE
Changed the mac_install.sh url that was pointing to an invalid urL

### DIFF
--- a/install_mac.sh
+++ b/install_mac.sh
@@ -8,7 +8,7 @@ fi
 
 echo "* Downloading im-select..."
 
-curl -Ls -o /usr/local/bin/im-select https://github.com/daipeihust/im-select/raw/master/im-select-mac/out/intel/im-select
+curl -Ls -o /usr/local/bin/im-select https://github.com/daipeihust/im-select/master/macOS/out/intel/im-select 
 
 chmod 777 /usr/local/bin/im-select
 


### PR DESCRIPTION
Updated the url for the script that mac_install.sh downloads, as it was broken.
Now pointing to raw.github.com/.../correct-dir/...
