### PR TITLE
fix: 修复im-select-mspy执行后退出耗时过长的问题

### DIFF
--- a/win-mspy/main.cc
+++ b/win-mspy/main.cc
@@ -29,7 +29,7 @@ struct CliOptions
 {
   // no prefix
   wstring mode;
-  // -k= 
+  // -k=
   wstring switch_keys;
   // -t=
   wstring taskbar_name;
@@ -230,7 +230,7 @@ int wmain(int argc, wchar_t * argv[])
 
   if (!ime_button.pElement)
   {
-    return 1;
+    exit(1);
   }
 
 
@@ -251,5 +251,5 @@ int wmain(int argc, wchar_t * argv[])
 
 
   CoUninitialize();
-  return 0;
+  exit(0);
 }


### PR DESCRIPTION
使用 im-select-mspy 的过程中发现其执行后需要较长时间退出程序，调整为 exit 后整体耗时从 3s 左右降为 0.2~0.3s

相关 issue: https://github.com/daipeihust/im-select/issues/65